### PR TITLE
Add the VitaGraph dataset

### DIFF
--- a/chapters/drug_discovery_kgs.md
+++ b/chapters/drug_discovery_kgs.md
@@ -2,6 +2,14 @@
 
 ### Public Resources
 
+#### 2025
+
+- **VitaGraph (arXiv 2025)**
+  - Francesco Madeddu, Lucia Testa, Gianluca De Carlo, Michele Pieroni, Andrea Mastropietro, Aris Anagnostopoulos, Paolo Tieri & Sergio Barbarossa
+  - [[Paper]](https://arxiv.org/abs/2505.11185)
+  - [[Dataset Download]](https://www.kaggle.com/datasets/gianlucadecarlods/vitagraph)
+  - [[Construction Code]](https://github.com/GiDeCarlo/VitaGraph)
+
 #### 2024
 
 - **HealX KG - Open Source Version (Nature Communications 2024)**


### PR DESCRIPTION
This pull request updates the `chapters/drug_discovery_kgs.md` file by adding a new public resource for 2025, titled "VitaGraph." The addition includes details about the authors, a link to the paper, a dataset download link, and a link to the construction code.

Content updates:

* Added a new subsection for 2025 under "Public Resources," introducing "VitaGraph," with references to the paper, dataset, and construction code.