### PR TITLE
Add OptimusKG resource for drug discovery

### DIFF
--- a/chapters/drug_discovery_kgs.md
+++ b/chapters/drug_discovery_kgs.md
@@ -2,6 +2,15 @@
 
 ### Public Resources
 
+#### 2026
+
+- **OptimusKG (arXiv 2026)**
+  - Vittor, Lucas, Ayush Noori, Iñaki Arango, Joaquín Polonuer, Sam Rodriques, Andrew White, David A. Clifton, & Marinka Zitnik.
+  - [[Paper]](https://arxiv.org/pdf/2604.27269)
+  - [[Dataset Download]](https://github.com/mims-harvard/optimuskg)
+  - [[Construction Code]](https://doi.org/10.7910/DVN/IYNGEV)
+  - [[Website]](https://optimuskg.ai)
+
 #### 2025
 
 - **VitaGraph (arXiv 2025)**


### PR DESCRIPTION
This pull request adds a new entry for the OptimusKG knowledge graph resource to the public resources section of the `chapters/drug_discovery_kgs.md` file. The entry includes authorship, a link to the paper, dataset download, construction code, and the official website.

- Added a new section for 2026 public resources and included detailed information and links for the OptimusKG project.